### PR TITLE
Resource filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem 'jbuilder', '~> 2.5'
 
 gem 'devise', '~> 4.4', '>= 4.4.3'
 gem 'active_model_serializers', '~> 0.10.8'
+gem 'has_scope', '~> 0.7.2'
+
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
     ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    has_scope (0.7.2)
+      actionpack (>= 4.1)
+      activesupport (>= 4.1)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
@@ -197,6 +200,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   devise (~> 4.4, >= 4.4.3)
+  has_scope (~> 0.7.2)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/api/resources_controller.rb
+++ b/app/controllers/api/resources_controller.rb
@@ -4,8 +4,7 @@ class Api::ResourcesController < ApplicationController
 
     def index
         resources = apply_scopes(Resource).all
-        puts resources
-        render json: resources.order(updated_at: :desc), status: :ok
+        render json: resources.order(updated_at: :desc).uniq, status: :ok
     end
 
     def show 

--- a/app/controllers/api/resources_controller.rb
+++ b/app/controllers/api/resources_controller.rb
@@ -1,6 +1,11 @@
 class Api::ResourcesController < ApplicationController
+    before_action :parse_tag_ids, only: [:index]
+    has_scope :by_tags, type: :array
+
     def index
-        render json: Resource.all.order(updated_at: :desc), status: :ok
+        resources = apply_scopes(Resource).all
+        puts resources
+        render json: resources.order(updated_at: :desc), status: :ok
     end
 
     def show 
@@ -35,4 +40,10 @@ class Api::ResourcesController < ApplicationController
         )
     end
 
+    # Before applying scopes need to parse URL params into array
+    def parse_tag_ids
+        if params.has_key?(:by_tags)
+            params[:by_tags] = JSON.parse(params[:by_tags])
+        end
+    end
 end

--- a/app/javascript/packs/app/assets/stylesheets/app.scss
+++ b/app/javascript/packs/app/assets/stylesheets/app.scss
@@ -3,6 +3,7 @@
 @import "./navbar";
 @import "./sidebar";
 @import "./layout";
+@import "./filter_sidebar";
 
 @import "./resource_list";
 @import "./resource_index_page";

--- a/app/javascript/packs/app/assets/stylesheets/filter_sidebar.scss
+++ b/app/javascript/packs/app/assets/stylesheets/filter_sidebar.scss
@@ -1,0 +1,7 @@
+.filter-sidebar {
+  padding: 20px;
+  padding-left: 40px;
+  padding-bottom: 100px;
+  height: 100vh;
+  overflow-y: auto;
+}

--- a/app/javascript/packs/app/assets/stylesheets/layout.scss
+++ b/app/javascript/packs/app/assets/stylesheets/layout.scss
@@ -7,6 +7,7 @@ h1 {
   font-size: 48px;
   font-weight: 600;
   margin-top: 0px;
+  margin-bottom: 24px;
 }
 
 h2 {
@@ -15,6 +16,7 @@ h2 {
   font-size: 36px;
   font-weight: 600;
   margin-top: 0px;
+  margin-bottom: 18px;
 }
 
 h3 {
@@ -23,6 +25,7 @@ h3 {
   font-size: 28px;
   font-weight: 600;
   margin-top: 0px;
+  margin-bottom: 14px;
 }
 
 p {

--- a/app/javascript/packs/app/assets/stylesheets/resource_index_page.scss
+++ b/app/javascript/packs/app/assets/stylesheets/resource_index_page.scss
@@ -2,7 +2,7 @@
   padding: 50px;
 }
 
-$sidebar-width: 200px;
+$sidebar-width: 300px;
 .resource-index-page-sidebar {
   position: fixed;
   width: $sidebar-width;

--- a/app/javascript/packs/app/assets/stylesheets/resource_list.scss
+++ b/app/javascript/packs/app/assets/stylesheets/resource_list.scss
@@ -31,3 +31,10 @@ $resource-list-card-height: 150px;
   font-size: 20px;
   font-weight: 600;
 }
+
+.resource-list-empty-state-container {
+  height: 60vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/javascript/packs/app/components/CreateResourcePage.jsx
+++ b/app/javascript/packs/app/components/CreateResourcePage.jsx
@@ -45,7 +45,6 @@ class CreateResourcePage extends React.Component {
 
   async componentDidMount() {
     await this.getResourceTags();
-    console.log(this.state);
   }
 
   async getResourceTags() {
@@ -109,7 +108,6 @@ class CreateResourcePage extends React.Component {
         });
       }
       this.setState({ selectedResourceTags: newSelectedResourceTags });
-      console.log(this.state);
     };
   }
 

--- a/app/javascript/packs/app/components/ResourceIndexFilterSidebar.jsx
+++ b/app/javascript/packs/app/components/ResourceIndexFilterSidebar.jsx
@@ -58,7 +58,6 @@ class ResourceIndexFilterSidebar extends FilterSidebar {
       }
     });
     this.setState({ sections: sectionsState });
-    console.log(sectionsState);
   }
 
   checkResourceTagCallback = resourceTagId => {
@@ -74,6 +73,7 @@ class ResourceIndexFilterSidebar extends FilterSidebar {
         });
       }
       this.setState({ checkedResourceTagIds: newCheckedResourceTagIds });
+      this.props.filterResourcesCallback(newCheckedResourceTagIds);
     };
   };
 

--- a/app/javascript/packs/app/components/ResourceIndexFilterSidebar.jsx
+++ b/app/javascript/packs/app/components/ResourceIndexFilterSidebar.jsx
@@ -1,106 +1,87 @@
 import React from "react";
 import { Classes, Icon, ITreeNode, Tooltip, Tree } from "@blueprintjs/core";
+import update from "immutability-helper";
 
 import FilterSidebar from "./common/FilterSidebar";
+
+import API from "../middleware/api";
 
 class ResourceIndexFilterSidebar extends FilterSidebar {
   constructor(props) {
     super(props);
 
     this.state = {
-      nodes: this.getInitialNodes(),
+      sections: [],
+      checkedResourceTagIds: new Set(),
     };
   }
 
-  componentDidMount() {}
+  async componentDidMount() {
+    await this.getResourceTags();
+  }
 
-  getInitialNodes() {
-    return [
+  async getResourceTags() {
+    let sectionsState = [
       {
-        id: 0,
-        hasCaret: true,
-        isExpanded: true,
-        label: "Student Filters",
+        name: "student",
+        tags: [],
       },
       {
-        id: 1,
-        hasCaret: true,
-        isExpanded: true,
-        label: "Campus Filters",
+        name: "campus",
+        tags: [],
       },
       {
-        id: 2,
-        hasCaret: true,
-        isExpanded: true,
-        label: "Student Filters",
+        name: "community",
+        tags: [],
       },
       {
-        id: 3,
-        hasCaret: true,
-        isExpanded: true,
-        label: "Level of Urgency",
-      },
-      {
-        id: 4,
-        hasCaret: true,
-        isExpanded: true,
-        label: "Community Filters",
-      },
-      {
-        id: 5,
-        icon: "folder-close",
-        isExpanded: true,
-        label: <Tooltip content="I'm a folder <3">Folder 1</Tooltip>,
-        childNodes: [
-          {
-            id: 2,
-            icon: "document",
-            label: "Item 0",
-            secondaryLabel: (
-              <Tooltip content="An eye!">
-                <Icon icon="eye-open" />
-              </Tooltip>
-            ),
-          },
-          {
-            id: 3,
-            icon: "tag",
-            label:
-              "Organic meditation gluten-free, sriracha VHS drinking vinegar beard man.",
-          },
-          {
-            id: 4,
-            hasCaret: true,
-            icon: "folder-close",
-            label: <Tooltip content="foo">Folder 2</Tooltip>,
-            childNodes: [
-              { id: 5, label: "No-Icon Item" },
-              { id: 6, icon: "tag", label: "Item 1" },
-              {
-                id: 7,
-                hasCaret: true,
-                icon: "folder-close",
-                label: "Folder 3",
-                childNodes: [
-                  { id: 8, icon: "document", label: "Item 0" },
-                  { id: 9, icon: "tag", label: "Item 1" },
-                ],
-              },
-            ],
-          },
-        ],
+        name: "other",
+        tags: [],
       },
     ];
+
+    let resourceTags = await API.GetResourceTags();
+    resourceTags.forEach(tag => {
+      switch (tag.category) {
+        case "student":
+          sectionsState[0].tags.push(tag);
+          break;
+        case "campus":
+          sectionsState[1].tags.push(tag);
+          break;
+        case "community":
+          sectionsState[2].tags.push(tag);
+          break;
+        default:
+          sectionsState[3].tags.push(tag);
+          break;
+      }
+    });
+    this.setState({ sections: sectionsState });
+    console.log(sectionsState);
   }
+
+  checkResourceTagCallback = resourceTagId => {
+    return event => {
+      let newCheckedResourceTagIds;
+      if (this.state.checkedResourceTagIds.has(resourceTagId)) {
+        newCheckedResourceTagIds = update(this.state.checkedResourceTagIds, {
+          $remove: [resourceTagId],
+        });
+      } else {
+        newCheckedResourceTagIds = update(this.state.checkedResourceTagIds, {
+          $add: [resourceTagId],
+        });
+      }
+      this.setState({ checkedResourceTagIds: newCheckedResourceTagIds });
+    };
+  };
 
   render() {
     return (
-      <Tree
-        contents={this.state.nodes}
-        onNodeClick={this.handleNodeClick}
-        onNodeCollapse={this.handleNodeCollapse}
-        onNodeExpand={this.handleNodeExpand}
-        className={Classes.ELEVATION_1}
+      <FilterSidebar
+        sections={this.state.sections}
+        checkTagCallback={this.checkResourceTagCallback}
       />
     );
   }

--- a/app/javascript/packs/app/components/ResourceIndexPage.jsx
+++ b/app/javascript/packs/app/components/ResourceIndexPage.jsx
@@ -1,13 +1,6 @@
 import React from "react";
 import ResourceList from "./ResourceList";
-import {
-  Button,
-  Classes,
-  Icon,
-  ITreeNode,
-  Tooltip,
-  Tree,
-} from "@blueprintjs/core";
+import { Button } from "@blueprintjs/core";
 import { Link } from "react-router-dom";
 
 import FilterSidebar from "./common/FilterSidebar";
@@ -31,12 +24,20 @@ class ResourceIndexPage extends React.Component {
     this.setState({ resources: resources, loaded: true });
   }
 
+  filterResources = async resourceTagIds => {
+    this.setState({ loaded: false });
+    let resources = await API.ResourcesIndex([...resourceTagIds]);
+    this.setState({ resources: resources, loaded: true });
+  };
+
   render() {
     return (
       <div className="container is-widescreen page-container">
         <Navbar />
         <div className="resource-index-page-sidebar">
-          <ResourceIndexFilterSidebar />
+          <ResourceIndexFilterSidebar
+            filterResourcesCallback={this.filterResources}
+          />
         </div>
         <div className="resource-index-page-main-container">
           <h2>BNS Resources</h2>

--- a/app/javascript/packs/app/components/ResourceList.jsx
+++ b/app/javascript/packs/app/components/ResourceList.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Card, Classes, Elevation } from "@blueprintjs/core";
+import { Card, Classes, Elevation, NonIdealState } from "@blueprintjs/core";
 import { Link } from "react-router-dom";
 
 import Placeholder from "images/placeholder-square.jpg";
@@ -7,7 +7,7 @@ import Placeholder from "images/placeholder-square.jpg";
 class ResourceList extends React.Component {
   renderResources() {
     if (!this.props.loaded) {
-      return [0, 1, 2].map(index => (
+      return [0, 1, 2, 3, 4, 5, 6, 7].map(index => (
         <Card
           interactive={false}
           elevation={Elevation.ZERO}
@@ -26,6 +26,16 @@ class ResourceList extends React.Component {
           </div>
         </Card>
       ));
+    } else if (this.props.resources.length === 0) {
+      return (
+        <div className="resource-list-empty-state-container">
+          <NonIdealState
+            icon="search"
+            title="No search results"
+            description="No resources matched the filter you've chosen. Please try again!"
+          />
+        </div>
+      );
     }
 
     return this.props.resources.map(resource => (

--- a/app/javascript/packs/app/components/ShowResourcePage.jsx
+++ b/app/javascript/packs/app/components/ShowResourcePage.jsx
@@ -18,7 +18,6 @@ class ShowResourcePage extends React.Component {
 
   async componentDidMount() {
     const resource = await API.ShowResource(this.props.match.params.id);
-    console.log(resource);
     this.setState({ resource: resource });
   }
 

--- a/app/javascript/packs/app/components/UpdateResourcePage.jsx
+++ b/app/javascript/packs/app/components/UpdateResourcePage.jsx
@@ -35,7 +35,6 @@ class UpdateResourcePage extends CreateResourcePage {
       },
       selectedResourceTags: selectedResourceTags,
     });
-    console.log(this.state);
   }
 
   getPageTitle() {

--- a/app/javascript/packs/app/components/common/FilterSidebar.jsx
+++ b/app/javascript/packs/app/components/common/FilterSidebar.jsx
@@ -5,18 +5,18 @@ class FilterSidebar extends React.Component {
   render() {
     console.log(this.props);
     return (
-      <div>
+      <div className="filter-sidebar">
         {this.props.sections.map((section, i) => {
           return (
             <div key={`section-${i}`}>
               <h3>{section.name}</h3>
-              <FormGroup label="Other Filters" labelFor="text-input">
+              <FormGroup>
                 {section.tags.map(tag => {
                   return (
                     <Checkbox
                       label={tag.name}
                       onChange={this.props.checkTagCallback(tag.id)}
-                      key={`resource-tag-${tag.id}`}
+                      key={`tag-${tag.id}`}
                     />
                   );
                 })}

--- a/app/javascript/packs/app/components/common/FilterSidebar.jsx
+++ b/app/javascript/packs/app/components/common/FilterSidebar.jsx
@@ -1,60 +1,30 @@
 import React from "react";
-import { Classes, Icon, ITreeNode, Tooltip, Tree } from "@blueprintjs/core";
+import { FormGroup, Checkbox } from "@blueprintjs/core";
 
 class FilterSidebar extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      nodes: this.getInitialNodes(),
-    };
-  }
-
-  componentDidMount() {}
-
-  getInitialNodes() {
-    throw new Error("Not Implemented.");
-  }
-
-  handleNodeClick = (node, nodePath, e) => {
-    const originallySelected = node.isSelected;
-    if (!e.shiftKey) {
-      this.forEachNode(this.state.nodes, n => (n.isSelected = false));
-    }
-    node.isSelected = originallySelected == null ? true : !originallySelected;
-    this.setState(this.state);
-  };
-
-  handleNodeExpand = node => {
-    node.isExpanded = true;
-    this.setState(this.state);
-  };
-
-  handleNodeCollapse = node => {
-    node.isExpanded = false;
-    this.setState(this.state);
-  };
-
-  forEachNode(nodes, callback) {
-    if (nodes == null) {
-      return;
-    }
-
-    for (const node of nodes) {
-      callback(node);
-      this.forEachNode(node.childNodes, callback);
-    }
-  }
-
   render() {
+    console.log(this.props);
     return (
-      <Tree
-        contents={this.state.nodes}
-        onNodeClick={this.handleNodeClick}
-        onNodeCollapse={this.handleNodeCollapse}
-        onNodeExpand={this.handleNodeExpand}
-        className={Classes.ELEVATION_1}
-      />
+      <div>
+        {this.props.sections.map((section, i) => {
+          return (
+            <div key={`section-${i}`}>
+              <h3>{section.name}</h3>
+              <FormGroup label="Other Filters" labelFor="text-input">
+                {section.tags.map(tag => {
+                  return (
+                    <Checkbox
+                      label={tag.name}
+                      onChange={this.props.checkTagCallback(tag.id)}
+                      key={`resource-tag-${tag.id}`}
+                    />
+                  );
+                })}
+              </FormGroup>
+            </div>
+          );
+        })}
+      </div>
     );
   }
 }

--- a/app/javascript/packs/app/components/common/FilterSidebar.jsx
+++ b/app/javascript/packs/app/components/common/FilterSidebar.jsx
@@ -3,7 +3,6 @@ import { FormGroup, Checkbox } from "@blueprintjs/core";
 
 class FilterSidebar extends React.Component {
   render() {
-    console.log(this.props);
     return (
       <div className="filter-sidebar">
         {this.props.sections.map((section, i) => {

--- a/app/javascript/packs/app/middleware/api.js
+++ b/app/javascript/packs/app/middleware/api.js
@@ -1,8 +1,11 @@
 import Requester from "./requester";
 
 class API {
-  static async ResourcesIndex() {
-    return await Requester.get("/api/resources");
+  static async ResourcesIndex(tags) {
+    if (!tags || tags.length === 0) {
+      return await Requester.get("/api/resources");
+    }
+    return await Requester.get(`/api/resources?by_tags=[${tags}]`);
   }
 
   static async ShowResource(id) {

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -18,4 +18,7 @@ class Resource < ApplicationRecord
     has_many :resource_tags, through: :resource_tag_instances
 
     accepts_nested_attributes_for :resource_tag_instances, allow_destroy: true
+
+    # Filter by multiple tags on OR condition
+    scope :by_tags, -> tag_ids { puts tag_ids; joins(:resource_tag_instances).where(resource_tag_instances: { resource_tag_id: tag_ids }) }
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -20,5 +20,10 @@ class Resource < ApplicationRecord
     accepts_nested_attributes_for :resource_tag_instances, allow_destroy: true
 
     # Filter by multiple tags on OR condition
-    scope :by_tags, -> tag_ids { puts tag_ids; joins(:resource_tag_instances).where(resource_tag_instances: { resource_tag_id: tag_ids }) }
+    scope :by_tags, -> tag_ids { filter_by_tags(tag_ids) }
+
+    def self.filter_by_tags(tag_ids)
+        joins(:resource_tag_instances)
+            .where(resource_tag_instances: { resource_tag_id: tag_ids })
+    end
 end


### PR DESCRIPTION
Resources can be filtered now! Additional things:
* Cleaned up sidebar styling (not collapsible yet)
* Reactive update without refresh
* Skeleton resources during load
* Empty state for nothing found

![resource-filtering](https://user-images.githubusercontent.com/13477279/49138750-e4ae8100-f2a4-11e8-9eea-4b95ba3b0930.gif)

Housekeeping for this feature (priority): 
- [ ] Collapsible categories on sidebar (low) 
- [ ] Finalize style (low) 
- [ ] Cache last resource list length and use that to render skeleton length (cool cosmetic, really low)

Next is sort. 