### PR TITLE
Resource show styling

### DIFF
--- a/app/javascript/app/assets/stylesheets/_variables.scss
+++ b/app/javascript/app/assets/stylesheets/_variables.scss
@@ -11,6 +11,7 @@ $font-stack: "Source Sans Pro", "Lato", "Helvetica", sans-serif;
 // Colors
 
 $off-black: #4a4a4a;
+$off-white: #fafafa;
 $dark-gray: #828282;
 $dark-blue: #3b7ea1;
 $gold: rgba(196, 130, 14, 0.35);

--- a/app/javascript/app/assets/stylesheets/layout.scss
+++ b/app/javascript/app/assets/stylesheets/layout.scss
@@ -4,14 +4,16 @@
 h1 {
   font-family: $font-stack;
   color: $off-black;
-  font-size: 48px;
+  line-height: 1.2em;
+  font-size: 40px;
   font-weight: 600;
 }
 
 h2 {
   font-family: $font-stack;
   color: $off-black;
-  font-size: 36px;
+  line-height: 1.2em;
+  font-size: 32px;
   font-weight: 600;
   margin-top: 32px;
   margin-bottom: 24px;
@@ -20,7 +22,8 @@ h2 {
 h3 {
   font-family: $font-stack;
   color: $off-black;
-  font-size: 28px;
+  line-height: 1.2em;
+  font-size: 24px;
   font-weight: 600;
   margin-top: 24px;
   margin-bottom: 18px;
@@ -29,7 +32,8 @@ h3 {
 h4 {
   font-family: $font-stack;
   color: $off-black;
-  font-size: 20px;
+  line-height: 1.2em;
+  font-size: 18px;
   font-weight: 600;
   margin-top: 18px;
   margin-bottom: 12px;
@@ -38,7 +42,7 @@ h4 {
 p {
   font-family: $font-stack;
   color: $dark-gray;
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 400;
   line-height: 1.5em;
 }

--- a/app/javascript/app/assets/stylesheets/resource_index_page.scss
+++ b/app/javascript/app/assets/stylesheets/resource_index_page.scss
@@ -38,8 +38,10 @@ $sidebar-width: 300px;
 }
 
 // Resource modal
+$resource-modal-bg-color: $off-white;
 .resource-modal-dialog {
   width: 1000px;
+  background-color: $resource-modal-bg-color;
 }
 
 .resource-modal-body {
@@ -72,11 +74,52 @@ $sidebar-width: 300px;
   }
 }
 
+.resource-modal-table {
+  margin: 12px 0px;
+  h4 {
+    margin: 0px;
+  }
+  td {
+    vertical-align: middle !important;
+    &.cell-fixed-width {
+      width: 50px;
+    }
+  }
+  > thead {
+    th {
+      padding-left: 0px;
+    }
+  }
+  > tbody {
+    border-color: rgba(0, 0, 0, 0);
+    p {
+      margin: 0px !important;
+    }
+  }
+}
+
 .resource-modal-text-body {
   position: relative;
-  height: 160px;
+  max-height: 160px;
   overflow-y: hidden;
 
+  // Make segments closer to each other in preview
+  // (TODO: Move into compressed styles)
+  h2 {
+    margin-top: 16px;
+    margin-bottom: 12px;
+  }
+  h3 {
+    margin-top: 12px;
+    margin-bottom: 8px;
+  }
+  h4 {
+    margin-top: 8px;
+    margin-bottom: 6px;
+  }
+  p {
+    margin-bottom: 4px;
+  }
   // Fade bottom edge
   &::after {
     content: "";
@@ -88,7 +131,7 @@ $sidebar-width: 300px;
     background-image: linear-gradient(
       to bottom,
       rgba(255, 255, 255, 0),
-      #ebf1f5
+      $resource-modal-bg-color
     );
     width: 100%;
     height: 40px;

--- a/app/javascript/app/assets/stylesheets/resource_index_page.scss
+++ b/app/javascript/app/assets/stylesheets/resource_index_page.scss
@@ -67,6 +67,9 @@ $sidebar-width: 300px;
 }
 
 .resource-modal-text {
+  > p {
+    font-size: 16px;
+  }
 }
 
 .resource-modal-text-body {

--- a/app/javascript/app/assets/stylesheets/resource_list.scss
+++ b/app/javascript/app/assets/stylesheets/resource_list.scss
@@ -3,7 +3,7 @@
 .resource-list {
 }
 
-$resource-list-card-height: 150px;
+$resource-list-card-height: 160px;
 .resource-list-card {
   display: flex;
   flex-flow: row nowrap;
@@ -17,8 +17,8 @@ $resource-list-card-height: 150px;
 .resource-list-card-image {
   display: block;
   margin: 20px;
-  width: 110px;
-  height: 110px;
+  width: 120px;
+  height: 120px;
   object-fit: scale-down;
 }
 

--- a/app/javascript/app/components/ResourceIndexPage.jsx
+++ b/app/javascript/app/components/ResourceIndexPage.jsx
@@ -11,6 +11,7 @@ import {
   Tabs,
   Tab,
   Tooltip,
+  Callout,
 } from "@blueprintjs/core";
 import { Link } from "react-router-dom";
 import update from "immutability-helper";
@@ -23,6 +24,7 @@ import API from "../middleware/api";
 import { checkUserSignedIn, checkUserIsAdmin } from "../utils/session";
 
 import Placeholder from "images/bear.png";
+import { intentClass } from "@blueprintjs/core/lib/esm/common/classes";
 
 class ResourceIndexPage extends React.Component {
   constructor(props) {
@@ -154,11 +156,17 @@ class ResourceIndexPage extends React.Component {
               <h3 style={{ marginTop: "0px" }}>{resource.title}</h3>
               <p>{resource.description}</p>
 
+              {resource.deadlines && (
+                <Callout title="Deadlines Notice" intent={Intent.WARNING}>
+                  {resource.deadlines}
+                </Callout>
+              )}
+
               <h4>Eligibility</h4>
               <p>{resource.eligibility}</p>
 
-              <h4>Notes</h4>
-              <p>{resource.notes}</p>
+              {/* <h4>Notes</h4>
+              <p>{resource.notes}</p> */}
 
               <h4>Preview</h4>
               <div

--- a/app/javascript/app/components/ResourceIndexPage.jsx
+++ b/app/javascript/app/components/ResourceIndexPage.jsx
@@ -12,6 +12,8 @@ import {
   Tab,
   Tooltip,
   Callout,
+  HTMLTable,
+  Icon,
 } from "@blueprintjs/core";
 import { Link } from "react-router-dom";
 import update from "immutability-helper";
@@ -162,13 +164,57 @@ class ResourceIndexPage extends React.Component {
                 </Callout>
               )}
 
-              <h4>Eligibility</h4>
-              <p>{resource.eligibility}</p>
+              <HTMLTable small interactive className="resource-modal-table">
+                <thead>
+                  <tr>
+                    <th colSpan={2}>
+                      <h4>Quick Facts</h4>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <Icon icon="map-marker" iconSize={16} />
+                    </td>
+                    <td>
+                      <p>{resource.address}</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <Icon icon="phone" iconSize={16} />
+                    </td>
+                    <td>
+                      <p>{resource.contact_info}</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <Icon icon="time" iconSize={16} />
+                    </td>
+                    <td>
+                      <p>{resource.hours_of_operation}</p>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <Icon icon="dollar" iconSize={16} />
+                    </td>
+                    <td>
+                      <p>{resource.cost}</p>
+                    </td>
+                  </tr>
+                </tbody>
+              </HTMLTable>
 
-              {/* <h4>Notes</h4>
-              <p>{resource.notes}</p> */}
+              {resource.eligibility && (
+                <Callout title="Eligibility" intent={Intent.PRIMARY}>
+                  {resource.eligibility}
+                </Callout>
+              )}
 
-              <h4>Preview</h4>
+              <h4>Additional Notes</h4>
               <div
                 dangerouslySetInnerHTML={{ __html: resource.body }}
                 className="resource-modal-text-body"

--- a/app/serializers/api/resource_serializer.rb
+++ b/app/serializers/api/resource_serializer.rb
@@ -33,4 +33,11 @@ class Api::ResourceSerializer < ActiveModel::Serializer
     end
     scope[:current_user].liked? object
   end
+
+  def address
+    if object.address.present?
+      return "#{object.address["street_address"]}, #{object.address["city"]}, #{object.address["state"]} #{object.address["zip"]}"
+    end
+    return "N/A"
+  end
 end


### PR DESCRIPTION
Includes a bunch of new fields in the show modal and cleans up a lot of CSS:
<img width="1010" alt="screen shot 2019-02-19 at 2 19 52 am" src="https://user-images.githubusercontent.com/13477279/53007984-36bafa80-33ed-11e9-9453-7b5d41b25dfd.png">

If fields don't exist we don't show (not supported on the table yet): 
<img width="1013" alt="screen shot 2019-02-19 at 2 21 18 am" src="https://user-images.githubusercontent.com/13477279/53008016-49353400-33ed-11e9-8c27-68955fd9189a.png">

